### PR TITLE
Support a custom syntax for sending mentions in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ client.conversation_roster.users
 
 This will return an array of `User` instances for everyone in the conversation.
 
+### Bot Details
+
+To get information about your bot user, just call
+
+```ruby
+client.me
+```
+
+This will return a `Me` instance with the following attributes:
+`:account_id, :name, :email, :picture`
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/stride.rb
+++ b/lib/stride.rb
@@ -1,5 +1,6 @@
 require 'stride/version'
 require 'stride/configuration'
+require 'stride/atlassian_document_format_expander'
 require 'stride/base_request'
 require 'stride/authorized_request'
 require 'stride/token'

--- a/lib/stride.rb
+++ b/lib/stride.rb
@@ -13,6 +13,7 @@ require 'stride/markdown_document'
 require 'stride/conversation'
 require 'stride/conversation_roster'
 require 'stride/bot_mention'
+require 'stride/me'
 
 module Stride
   class << self

--- a/lib/stride/atlassian_document_format_expander.rb
+++ b/lib/stride/atlassian_document_format_expander.rb
@@ -4,13 +4,114 @@ module Stride
       self.initial_json = initial_json
     end
 
-    def json
-      # return initial_json unless initial_json.is_a?(Hash÷)
+    def as_json
+      return initial_json unless initial_json.has_key?('content')
+
+      initial_json['content'] = ContentBlocks.new(initial_json['content']).as_json
       initial_json
     end
 
     private
 
     attr_accessor :initial_json
+
+    class ContentBlocks
+      def initialize(initial_json)
+        self.initial_json = initial_json
+      end
+
+      def as_json
+        wrapped_blocks.map(&:as_json).flatten
+      end
+
+      private
+
+      attr_accessor :initial_json
+
+      def wrapped_blocks
+        initial_json.map do |content_block_json|
+          if content_block_json.has_key?('content')
+            content_block_json['content'] = ContentBlocks.new(content_block_json['content']).as_json
+            content_block_json
+          else
+            ContentBlock.new(content_block_json)
+          end
+        end
+      end
+    end
+
+    class ContentBlock
+      MENTION_REGEX = /@@([a-zA-Z]+)\|([a-zA-Z0-9]+)@@/
+      MENTION_REGEX_WITHOUT_GROUPS = /@@[a-zA-Z]+\|[a-zA-Z0-9]+@@/
+
+      def initialize(initial_json)
+        self.initial_json = initial_json
+      end
+
+      def as_json
+        split? ? split_json : initial_json
+      end
+
+      private
+
+      attr_accessor :initial_json
+
+      def split?
+        initial_json.has_key?('text') && match_data.present?
+      end
+
+      def match_data
+        @match_data ||= initial_json['text'].match(MENTION_REGEX)
+      end
+
+      def split_json
+        split_blocks.map(&:as_json)
+      end
+
+      def split_blocks
+        return text_blocks_joined_by_mention_block if mention_in_middle?
+
+        if mention_at_beginning?
+          text_blocks_joined_by_mention_block.prepend mention_block
+        else
+          text_blocks_joined_by_mention_block << mention_block
+        end
+      end
+
+      def text_blocks_joined_by_mention_block
+        @text_blocks_joined_by_mention_block ||= text_blocks.each_with_object([]) do |text_block, all_blocks|
+          all_blocks << text_block
+          all_blocks << mention_block unless text_block == text_blocks.last
+        end.reject { |block| block.as_json['text'] == '' }
+      end
+
+      def mention_in_middle?
+        text_blocks_joined_by_mention_block.count > 1
+      end
+
+      def mention_at_beginning?
+        (initial_json['text'] =~ MENTION_REGEX_WITHOUT_GROUPS) == 0
+      end
+
+      def text_blocks
+        @text_blocks ||= initial_json['text'].split(MENTION_REGEX_WITHOUT_GROUPS).map do |text|
+          self.class.new({
+            "type" => "text",
+            "text" => text
+          })
+        end
+      end
+
+      def mention_block
+        @mention_block ||= self.class.new({
+          "type" => "mention",
+          "attrs" => {
+            "id"          => match_data[2],
+            "text"        => "@#{match_data[1]}",
+            "accessLevel" => "CONTAINER"
+          }
+        })
+      end
+    end
   end
 end

--- a/lib/stride/atlassian_document_format_expander.rb
+++ b/lib/stride/atlassian_document_format_expander.rb
@@ -1,0 +1,16 @@
+module Stride
+  class AtlassianDocumentFormatExpander
+    def initialize(initial_json)
+      self.initial_json = initial_json
+    end
+
+    def json
+      # return initial_json unless initial_json.is_a?(Hash÷)
+      initial_json
+    end
+
+    private
+
+    attr_accessor :initial_json
+  end
+end

--- a/lib/stride/client.rb
+++ b/lib/stride/client.rb
@@ -41,6 +41,10 @@ module Stride
       ConversationRoster.fetch!(access_token, cloud_id, conversation_id)
     end
 
+    def me
+      Me.fetch!(access_token)
+    end
+
     private
 
     attr_accessor :cloud_id, :conversation_id

--- a/lib/stride/markdown_document.rb
+++ b/lib/stride/markdown_document.rb
@@ -9,7 +9,7 @@ module Stride
     end
 
     def as_json
-      request.json
+      AtlassianDocumentFormatExpander.new(request.json).json
     end
 
     private

--- a/lib/stride/me.rb
+++ b/lib/stride/me.rb
@@ -1,0 +1,38 @@
+module Stride
+  class Me
+    attr_accessor :account_id, :name, :email, :picture
+
+    def self.fetch!(access_token)
+      new(MeRequest.new(access_token).json)
+    end
+
+    def initialize(json)
+      self.account_id = json['account_id']
+      self.name       = json['name']
+      self.email      = json['email']
+      self.picture    = json['picture']
+    end
+
+    private
+
+    class MeRequest < AuthorizedRequest
+      def initialize(access_token)
+        self.access_token = access_token
+      end
+
+      private
+
+      attr_accessor :cloud_id, :user_id
+
+      def uri
+        URI(
+          "#{Stride.configuration.api_base_url}/me"
+        )
+      end
+
+      def request_class
+        Net::HTTP::Get
+      end
+    end
+  end
+end

--- a/spec/atlassian_document_format_expander_spec.rb
+++ b/spec/atlassian_document_format_expander_spec.rb
@@ -1,0 +1,177 @@
+require 'spec_helper'
+
+module Stride
+  RSpec.describe AtlassianDocumentFormatExpander do
+    let(:expander) { described_class.new(initial_json) }
+
+    describe '#json' do
+      context 'when nothing should be expanded' do
+        let(:initial_json) do
+          {
+            "version" => 1,
+            "type" => "doc",
+            "content" => [
+              {
+                "type" => "paragraph",
+                "content" => [
+                  {
+                    "type" => "text",
+                    "text" => "hi"
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        it 'just returns it' do
+          expect(expander.json).to eq initial_json
+        end
+      end
+
+      context 'when doing weird mention markup' do
+        context 'mention in the middle of text' do
+          let(:initial_json) do
+            {
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "text",
+                      "text" => "hi @@Bonusly|ab123@@ how you doing"
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+
+          it 'splits it out into a mention' do
+            expect(expander.json).to eq ({
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "text",
+                      "text" => "hi "
+                    },
+                    {
+                      "type" => "mention",
+                      "attrs" => {
+                        "id"          => "ab123",
+                        "text"        => "@Bonusly",
+                        "accessLevel" => "CONTAINER"
+                      }
+                    },
+                    {
+                      "type" => "text",
+                      "text" => " how you doing"
+                    }
+                  ]
+                }
+              ]
+            })
+          end
+        end
+
+        context 'mention at the beginning of text' do
+          let(:initial_json) do
+            {
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "text",
+                      "text" => "@@Bonusly|ab123@@ how you doing"
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+
+          it 'splits it out into a mention' do
+            expect(expander.json).to eq ({
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "mention",
+                      "attrs" => {
+                        "id"          => "ab123",
+                        "text"        => "@Bonusly",
+                        "accessLevel" => "CONTAINER"
+                      }
+                    },
+                    {
+                      "type" => "text",
+                      "text" => " how you doing"
+                    }
+                  ]
+                }
+              ]
+            })
+          end
+        end
+
+        context 'mention at the end of text' do
+          let(:initial_json) do
+            {
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "text",
+                      "text" => "hi @@Bonusly|ab123@@"
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+
+          it 'splits it out into a mention' do
+            expect(expander.json).to eq ({
+              "version" => 1,
+              "type" => "doc",
+              "content" => [
+                {
+                  "type" => "paragraph",
+                  "content" => [
+                    {
+                      "type" => "text",
+                      "text" => "hi "
+                    },
+                    {
+                      "type" => "mention",
+                      "attrs" => {
+                        "id"          => "ab123",
+                        "text"        => "@Bonusly",
+                        "accessLevel" => "CONTAINER"
+                      }
+                    }
+                  ]
+                }
+              ]
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/atlassian_document_format_expander_spec.rb
+++ b/spec/atlassian_document_format_expander_spec.rb
@@ -25,7 +25,7 @@ module Stride
         end
 
         it 'just returns it' do
-          expect(expander.json).to eq initial_json
+          expect(expander.as_json).to eq initial_json
         end
       end
 
@@ -50,7 +50,7 @@ module Stride
           end
 
           it 'splits it out into a mention' do
-            expect(expander.json).to eq ({
+            expect(expander.as_json).to eq ({
               "version" => 1,
               "type" => "doc",
               "content" => [
@@ -100,7 +100,7 @@ module Stride
           end
 
           it 'splits it out into a mention' do
-            expect(expander.json).to eq ({
+            expect(expander.as_json).to eq ({
               "version" => 1,
               "type" => "doc",
               "content" => [
@@ -146,7 +146,7 @@ module Stride
           end
 
           it 'splits it out into a mention' do
-            expect(expander.json).to eq ({
+            expect(expander.as_json).to eq ({
               "version" => 1,
               "type" => "doc",
               "content" => [
@@ -171,6 +171,53 @@ module Stride
             })
           end
         end
+      end
+    end
+  end
+
+  RSpec.describe AtlassianDocumentFormatExpander::ContentBlock do
+    let(:content_block) { described_class.new(initial_json) }
+
+    context 'when nothing to split' do
+      let(:initial_json) do
+        {
+          "type" => "text",
+          "text" => "hi"
+        }
+      end
+
+      it 'returns the initial json' do
+        expect(content_block.as_json).to eq initial_json
+      end
+    end
+
+    context 'when things to split' do
+      let(:initial_json) do
+        {
+          "type" => "text",
+          "text" => "hi @@Bonusly|ab123@@ sup"
+        }
+      end
+
+      it 'returns the appropriate json' do
+        expect(content_block.as_json).to eq([
+          {
+            "type" => "text",
+            "text" => "hi "
+          },
+          {
+            "type" => "mention",
+            "attrs" => {
+              "id" => "ab123",
+              "text" => "@Bonusly",
+              "accessLevel" => "CONTAINER"
+            }
+          },
+          {
+            "type" => "text",
+            "text" => " sup"
+          }
+        ])
       end
     end
   end

--- a/spec/me_spec.rb
+++ b/spec/me_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Stride
+  RSpec.describe Me do
+    describe '.fetch!' do
+      before do
+        Stride.configure do |config|
+          config.client_id     = 'some client id'
+          config.client_secret = 'some client secret'
+        end
+      end
+
+      context 'when successful' do
+        before do
+          stub_request(:get, "https://api.atlassian.com/me").
+            with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access-token', 'Content-Type'=>'application/json', 'Host'=>'api.atlassian.com', 'User-Agent'=>'Ruby'}).
+            to_return(status: 200, body: "{\"account_id\":\"bot-account-id\",\"name\":\"Bonusly\",\"email\":\"bot-email@connect.atlassian.com\",\"picture\":\"https://avatar-cdn.atlassian.com/bot-picture?by=hash\"}", headers: {})
+        end
+
+        let(:me) { described_class.fetch!('access-token') }
+
+        it 'fetches and parses a user' do
+          expect(me).to be_a described_class
+        end
+
+        specify { expect(me.account_id).to eq 'bot-account-id' }
+        specify { expect(me.name).to eq 'Bonusly' }
+        specify { expect(me.email).to eq 'bot-email@connect.atlassian.com' }
+        specify { expect(me.picture).to eq 'https://avatar-cdn.atlassian.com/bot-picture?by=hash' }
+      end
+
+      context 'when failed' do
+        before do
+          stub_request(:get, "https://api.atlassian.com/me").
+            with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access-token', 'Content-Type'=>'application/json', 'Host'=>'api.atlassian.com', 'User-Agent'=>'Ruby'}).
+            to_return(
+              status: 403,
+              body: '{"error":"access denied or something"}',
+              headers: {}
+            )
+        end
+
+        it 'throws an exception' do
+          expect {
+            described_class.fetch!('access-token')
+          }.to raise_error ApiFailure
+        end
+      end
+    end
+  end
+end

--- a/stride.gemspec
+++ b/stride.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
This way we can make `@Bonusly` a mention in the help text.